### PR TITLE
[DOC]:reorganize examples directories

### DIFF
--- a/python/doc/examples/example1/example1.rst
+++ b/python/doc/examples/example1/example1.rst
@@ -1,0 +1,24 @@
+Example 1
+=========
+
+1- Problem statement
+--------------------
+.. math::
+
+    \begin{aligned}
+    & \underset{x}{\text{minimize}}
+    & & \mathbb{E}_{\cD}((x_0-2)^2 + 2x_1^2 -4x_1 + \Theta) \\
+    & \text{subject to}
+    & & \mathbb{P}_{\cD}(-x_0 + 4x_1 + \Theta -3 \leq 0) \geq 0.9 \\
+    & & & \Theta \thicksim \cU(1, 3)
+    \end{aligned}
+
+2- Solution
+-----------
+.. math::
+
+    x^* = [2.2, 0.6]
+
+3- Resolution
+-------------
+.. literalinclude:: ../../t_example1.py

--- a/python/doc/examples/example2/example2.rst
+++ b/python/doc/examples/example2/example2.rst
@@ -1,0 +1,26 @@
+Example 2
+=========
+
+
+1- Problem statement
+--------------------
+.. math::
+
+    \begin{aligned}
+    & \underset{x}{\text{minimize}}
+    & & \mathbb{E}_{\cD}(\sqrt{x_0} \sqrt{x_1} \Theta) \\
+    & \text{subject to}
+    & & 2x_1 + 4x_0 - 120 \leq 0 \\
+    & & & \Theta \thicksim \cN(1, 3)
+    \end{aligned}
+
+2- Solution
+-----------
+.. math::
+
+    x^* = [15, 30]
+
+3- Resolution
+-------------
+.. literalinclude:: ../../t_example2.py
+

--- a/python/doc/examples/example3/example3.rst
+++ b/python/doc/examples/example3/example3.rst
@@ -1,0 +1,25 @@
+Example 3
+=========
+
+1- Problem statement
+--------------------
+.. math::
+
+    \begin{aligned}
+    & \underset{x}{\text{minimize}}
+    & & \mathbb{E}_{\cD}(x^3 - x + \Theta) \\
+    & \text{subject to}
+    & & \mathbb{P}_{\cD}(x + \Theta - 2 \leq 0) \geq 0.9 \\
+    & & & \Theta \thicksim \cE(2)
+    \end{aligned}
+
+2- Solution
+-----------
+.. math::
+
+    x^* = -1
+
+3- Resolution
+-------------
+.. literalinclude:: ../../t_example3.py
+

--- a/python/doc/examples/example4/example4.rst
+++ b/python/doc/examples/example4/example4.rst
@@ -1,0 +1,26 @@
+Example 4
+=========
+
+1- Problem statement
+--------------------
+.. math::
+
+    \begin{aligned}
+    & \underset{x}{\text{minimize}}
+    & & \mathbb{E}_{\cD}(\cos(x) \sin(\Theta)) \\
+    & \text{subject to}
+    & & \mathbb{P}_{\cD}(-2 - x + \Theta \leq 0) \geq 0.9 \\
+    & & & x - 4 \leq 0 \\
+    & & & \Theta \thicksim \cU(0, 2)
+    \end{aligned}
+
+2- Solution
+-----------
+.. math::
+
+    x^* = \pi
+
+3- Resolution
+-------------
+.. literalinclude:: ../../t_example4.py
+

--- a/python/doc/examples/example5/example5.rst
+++ b/python/doc/examples/example5/example5.rst
@@ -1,0 +1,34 @@
+Example 5 : Mean measure
+========================
+
+1- Problem statement
+--------------------
+
+Note `f` the parametric function defined by:
+ 
+.. math::
+
+    \begin{aligned}
+    & f(x, \theta)=x \theta
+    \end{aligned}
+
+`x` and :math:`\theta` being respectively the variable and parameter.
+
+The goal is to compute the mean measure of `f` assuming the random variable :math:`\Theta` follows a distribution :math:`\cD=\cN(2.0,0.1)`, i.e.:
+
+.. math::
+
+    M_{f, \cD}(x) = \int_{Supp(\cD)} x \theta p(\theta) d \theta = x \mathbb{E}(\Theta)=2.0x 
+
+
+2- Solution
+-----------
+.. math::
+
+    M_{f, \cD}(1.0) = 2.0
+
+3- Resolution
+-------------
+.. literalinclude:: ../../t_example5.py
+
+

--- a/python/doc/examples/examples.rst
+++ b/python/doc/examples/examples.rst
@@ -1,103 +1,11 @@
 Examples
 ========
 
-Example 1
----------
+.. toctree::
+   :maxdepth: 2
 
-1- Problem statement
-````````````````````
-.. math::
-
-    \begin{aligned}
-    & \underset{x}{\text{minimize}}
-    & & \mathbb{E}_{\cD}((x_0-2)^2 + 2x_1^2 -4x_1 + \Theta) \\
-    & \text{subject to}
-    & & \mathbb{P}_{\cD}(-x_0 + 4x_1 + \Theta -3 \leq 0) \geq 0.9 \\
-    & & & \Theta \thicksim \cU(1, 3)
-    \end{aligned}
-
-2- Solution
-```````````
-.. math::
-
-    x^* = [2.2, 0.6]
-
-3- Resolution
-`````````````
-.. literalinclude:: ../t_example1.py
-
-Example 2
----------
-
-1- Problem statement
-````````````````````
-.. math::
-
-    \begin{aligned}
-    & \underset{x}{\text{minimize}}
-    & & \mathbb{E}_{\cD}(\sqrt{x_0} \sqrt{x_1} \Theta) \\
-    & \text{subject to}
-    & & \mathbb{P}_{\cD}(2x_1 + 4x_0 - 120 \leq 0) \geq 0.9 \\
-    & & & \Theta \thicksim \cN(1, 3)
-    \end{aligned}
-
-2- Solution
-```````````
-.. math::
-
-    x^* = [15, 30]
-
-3- Resolution
-`````````````
-.. literalinclude:: ../t_example2.py
-
-Example 3
----------
-
-1- Problem statement
-````````````````````
-.. math::
-
-    \begin{aligned}
-    & \underset{x}{\text{minimize}}
-    & & \mathbb{E}_{\cD}(x^3 - x + \Theta) \\
-    & \text{subject to}
-    & & \mathbb{P}_{\cD}(x + \Theta - 2 \leq 0) \geq 0.9 \\
-    & & & \Theta \thicksim \cE(2)
-    \end{aligned}
-
-2- Solution
-```````````
-.. math::
-
-    x^* = -1
-
-3- Resolution
-`````````````
-.. literalinclude:: ../t_example3.py
-
-Example 4
----------
-
-1- Problem statement
-````````````````````
-.. math::
-
-    \begin{aligned}
-    & \underset{x}{\text{minimize}}
-    & & \mathbb{E}_{\cD}(\cos(x) \sin(\Theta)) \\
-    & \text{subject to}
-    & & \mathbb{P}_{\cD}(-2 - x + \Theta \leq 0) \geq 0.9 \\
-    & & & x - 4 \leq 0 \\
-    & & & \Theta \thicksim \cU(0, 2)
-    \end{aligned}
-
-2- Solution
-```````````
-.. math::
-
-    x^* = \pi
-
-3- Resolution
-`````````````
-.. literalinclude:: ../t_example4.py
+   example1/example1
+   example2/example2
+   example3/example3
+   example4/example4
+   example5/example5

--- a/python/doc/index.rst
+++ b/python/doc/index.rst
@@ -13,6 +13,13 @@ User documentation
    :maxdepth: 2
 
    user_manual/user_manual
+
+Examples
+--------
+
+.. toctree::
+   :maxdepth: 2
+
    examples/examples
 
 Developer documentation

--- a/python/test/CMakeLists.txt
+++ b/python/test/CMakeLists.txt
@@ -99,6 +99,7 @@ ot_pyinstallcheck_test (example1)
 ot_pyinstallcheck_test (example2)
 ot_pyinstallcheck_test (example3)
 ot_pyinstallcheck_test (example4)
+ot_pyinstallcheck_test (example5)
 
 add_custom_target ( pyinstallcheck COMMAND ${CMAKE_CTEST_COMMAND} -R "^pyinstallcheck_"
                     DEPENDS ${PYINSTALLCHECK_TO_BE_RUN}

--- a/python/test/t_example5.expout
+++ b/python/test/t_example5.expout
@@ -1,0 +1,2 @@
+measure([1.0])= [2]
+nb evals= 360

--- a/python/test/t_example5.py
+++ b/python/test/t_example5.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import openturns as ot
+import otrobopt
+
+thetaDist = ot.Normal(2.0, 0.1)
+f_base = ot.NumericalMathFunction(['x', 'theta'], ['y'], ['x*theta'])
+f = ot.NumericalMathFunction(f_base, [1], thetaDist.getMean())
+measure = otrobopt.MeanMeasure(f, thetaDist)
+print ('measure([1.0])=', measure([1.0]))
+print ('nb evals=', f_base.getEvaluationCallsNumber())


### PR DESCRIPTION
2 modifications added:
- Change organization of directory "otrobopt/python/doc/examples" by adding one directory per example. Consequently, the file  "examples.rst" was modified.
- Add example5 illustrating how to use "Mean measure" capability 
